### PR TITLE
Temporarily disable business menu buttons.

### DIFF
--- a/frontend/src/app/business/business-settings/business-settings.component.html
+++ b/frontend/src/app/business/business-settings/business-settings.component.html
@@ -71,12 +71,12 @@
       </div>
       <nav class="business-registration__navigation">
         <ul class="business-registration__list">
-          <li class="business-registration__item"><a [routerLink]="['/business/business-config']"
+          <li class="business-registration__item"><a (click)="displayPopup()"
               class="business-registration__link">Menu<i class="fa-solid fa-arrow-right"></i></a></li>
           <li class="business-registration__item"><a (click)="displayPopup()"
               class="business-registration__link">Loyalty Stamps<i class="fa-solid fa-arrow-right"></i></a></li>
-          <li class="business-registration__item"><a href="#" class="business-registration__link">Business Photos<i
-                class="fa-solid fa-arrow-right"></i></a></li>
+          <li class="business-registration__item"><a (click)="displayPopup()" 
+              class="business-registration__link">Business Photos<i class="fa-solid fa-arrow-right"></i></a></li>
           <li class="business-registration__item"><a (click)="displayPopup()"
               class="business-registration__link">Get QR code<i class="fa-solid fa-arrow-right"></i></a></li>
         </ul>


### PR DESCRIPTION
For the sake of a complete and stable app experience for the Hackathon submission.. Soleil and I thought it best to disable the business menu buttons with an "under-construction" popup display.  If a user were to click on the buttons and go back to the registration screen, all the fields would reset which provides a pretty inconvenient user experience.  Rather, it was decided to _force_ them to register the business or go back to the map display.  This will be the temporary solution for now. 

