### PR TITLE
Create Transcript NG-yor.json

### DIFF
--- a/backend/src/transcript/NG-yor.json
+++ b/backend/src/transcript/NG-yor.json
@@ -1,0 +1,14 @@
+{
+  "Customer": "Olùrajà",
+  "Business": "Olùtajà",
+  "Back": "Padà",
+  "You need to use PiBrowser for the feature": "O ní láti lo PiBrowser fún ìgbésẹ̀ yí",
+  "Progress": "Ìtẹ̀síwájú",
+  "History": "Ìṣe àtẹ̀yìnwá",
+  "Order": "Ràá",
+  "Stamp": "Jàn l'óntẹ̀",
+  "Menu": "Àwọn Èròjà Atọ́kùn",
+  "Info": "Ọ̀rọ̀ Ìjúwèé",
+  "Business Name": "Orúkọ òwò",
+  "Category": "Àyè Ìbámu",
+}


### PR DESCRIPTION
I propose to add the translation transcript to the repository, I'm merely using the words/phrased codings as a sample. Just as the "En.json" file represents the English language option for the App's navigators, then the Nigerian Yoruba language represents "NG-yor.json" file. Kindly review and I shall take the translations up for our Nigerian-Yoruba tribe, here in Nigeria.